### PR TITLE
Delegate all request methods to the request

### DIFF
--- a/spec/hi/request_spec.rb
+++ b/spec/hi/request_spec.rb
@@ -25,4 +25,14 @@ describe Hi::Request do
       expect(request.headers).to eq headers
     end
   end
+
+  describe '#host' do
+    it 'returns the host passed in the environment' do
+      host = 'amazing.dev'
+
+      request = described_class.new('HTTP_HOST' => host)
+
+      expect(request.host).to eq host
+    end
+  end
 end


### PR DESCRIPTION
`Hi::Request` is a pretty thin wrapper around `Rack::Request`. Let's delegate all the methods we use so that they can be accessed from a `Hi::Request` as well. 

This pleases Demeter. :tophat: 
